### PR TITLE
Completed format grammar

### DIFF
--- a/lib/eson/error_pass.rb
+++ b/lib/eson/error_pass.rb
@@ -5,7 +5,6 @@ module Eson
     
     UnknownSpecialForm = Class.new(StandardError)
 
-    #Detect unknown_special_forms Token in self
     #@return [TokenSeq] self when Token is not found
     #@raise [UnknownSpecialForm] unknown_special_forms Token found
     def verify_special_forms
@@ -24,12 +23,8 @@ module Eson
     def unknown_special_form_error_message(token)
       line_num = token.get_attribute(:line_no)
       "'#{token.lexeme}' is not a known special_form in" \
-      " line #{line_num}:\n" \
-      "#{line_num}. #{get_program_snippet(line_num)}"
-    end
-    
-    def get_program_snippet(line_num)
-      "#{self.get_program_line(line_num)}"
+      " line #{line_num}: " \
+      "#{get_program_snippet(line_num)}"
     end
   end
 end

--- a/lib/eson/eson_grammars.rb
+++ b/lib/eson/eson_grammars.rb
@@ -336,6 +336,13 @@ module Eson
            :action_mod => Module.new,
            :actions => [:assign_attribute],
            :terms => [:All]
+         },
+         {
+           :attr => :spaces_after,
+           :type => :s_attr,
+           :action_mod => Module.new,
+           :actions => [:assign_attribute],
+           :terms => [:colon]
          }])
     end
 

--- a/lib/eson/rule.rb
+++ b/lib/eson/rule.rb
@@ -187,7 +187,7 @@ module Eson
         "Error while parsing #{@name}." \
         " Expected a symbol of type :#{expected_token} but got a" \
         " :#{actual_token.name} instead in line #{line_num}:" \
-        "\n #{line_num}. #{token_seq.get_program_line(line_num)}\n"
+        "\n #{line_num}. #{token_seq.get_program_snippet(line_num)}\n"
       else
         "Error while parsing #{@name}." \
         " Expected a symbol of type :#{expected_token} but got a" \

--- a/lib/eson/token_pass.rb
+++ b/lib/eson/token_pass.rb
@@ -16,12 +16,12 @@ module Eson::TokenPass
 
     include Eson::ErrorPass
 
-    def get_program_line(line_no)
-      take_while{|i| i.get_attribute(:line_no) == line_no}
-        .each_with_object(""){|i, acc| acc.concat(i.lexeme.to_s)}
+    def get_program_snippet(line_no)
+      TokenSeq.new(self.select{|i| i.get_attribute(:line_no) == line_no})
+        .display_program
     end
 
-    def print_program
+    def display_program
       if self.none?{|i| i.get_attribute(:line_no).nil?}
         program_lines =
           self.slice_when do |t0, t1|
@@ -32,13 +32,18 @@ module Eson::TokenPass
             ts.first.get_attribute(:indent),
             ts.each_with_object("") do |j, acc|
               acc.concat(j.lexeme.to_s)
+              unit = j.get_attribute(:spaces_after)
+              space = unit.nil? ? "" : get_spaces(unit)
+              acc.concat(space)
             end
           ]
         end
         max_line = program_lines.length
-        program_lines.each do |i|
-          puts "#{get_line(i[0], max_line)}#{get_indent(i[1])}#{i[2]}"
+        program_lines.map do |i|
+          "#{get_line(i[0], max_line)}#{get_indentation(i[1])}#{i[2]}\n"
         end
+          .reduce(:concat)
+          .prepend("\n")
       end
     end
 
@@ -51,7 +56,7 @@ module Eson::TokenPass
       repeat_string(units, " ")
     end
 
-    def get_indent(units)
+    def get_indentation(units)
       repeat_string(units, "  ")
     end
 

--- a/lib/eson/tokenizer.rb
+++ b/lib/eson/tokenizer.rb
@@ -117,7 +117,8 @@ module Eson::TokenPass
 
     def json_symbols_to_tokens(json_symbol_seq, char_seq)
       envs = [{:attr => :line_no, :attr_value => 1},
-              {:attr => :indent, :attr_value => 0}]
+              {:attr => :indent, :attr_value => 0},
+              {:attr => :spaces_after, :attr_value => 1}]
       json_symbol_seq.each_with_object(Eson::TokenPass::TokenSeq.new) do |symbol, seq|
         case symbol.name
         when :object_start

--- a/test/eson_grammars_test.rb
+++ b/test/eson_grammars_test.rb
@@ -86,6 +86,17 @@ describe Eson::EsonGrammars do
       @lang.values.all?{|i| i.s_attr.include? :line_no}
         .must_equal true
     end
+    it "rules have s_attr indent" do
+      @lang.values.all?{|i| i.s_attr.include? :indent}
+        .must_equal true
+    end
+    it "only colon has s_attr spaces_after" do
+      @lang.colon.s_attr.include?(:spaces_after)
+        .must_equal true
+      (@lang.terms - [:colon])
+        .none?{|i| @lang.send(i).s_attr.include? :spaces_after}
+        .must_equal true
+    end
   end
 end
 

--- a/test/token_seq_test.rb
+++ b/test/token_seq_test.rb
@@ -39,8 +39,9 @@ end
 
 describe Eson::TokenPass::TokenSeq do
   before do
-    @alternation_rule = Eson::EsonGrammars.e4.sub_string
-    @concatenation_rule = Eson::EsonGrammars.e0.variable_identifier
+    @lang = Eson::EsonGrammars.format
+    @alternation_rule = @lang.sub_string
+    @concatenation_rule = @lang.variable_identifier
     @token_seq = Eson::TokenPass::TokenSeq.new(4) {Eson::LexemeCapture::Token.new}
   end
   

--- a/test/tokenizer_test.rb
+++ b/test/tokenizer_test.rb
@@ -15,7 +15,6 @@ describe Eson::TokenPass::Tokenizer do
     @token_sequence.must_be_instance_of Eson::TokenPass::TokenSeq
   end
   it "#add_line_numbers" do
-    @token_sequence.print_program
     @token_sequence.last.get_attribute(:line_no).must_equal 17
     @token_sequence.all?{|i| i.get_attribute(:line_no)}
       .must_equal true


### PR DESCRIPTION
Added :spaces_after s-attribute to format grammar, which is applied to colons and completed tests for this grammar. This grammar provides tokens with attributes to print well formatted eson.
- Using get_program_snippet and display_program to output programs from TokenSeq. These methods operate on the attributes introduced by the format attribute grammar so thought should be given as to how this coupling can be managed.
