### PR TITLE
Added output_file argument to fmt

### DIFF
--- a/bin/dote.rb
+++ b/bin/dote.rb
@@ -37,16 +37,24 @@ command 'fmt' do |c|
     end
     files = parse_file_paths(args)
     if files[:input_file]
-      if files[:output_file].nil?
-        program = File.open(files[:input_file]).read
-        grammar = Dote::DoteGrammars.esonf
+      program = File.open(files[:input_file]).read
+      grammar = Dote::DoteGrammars.esonf
         token_sequence = Dote::TokenPass.tokenize_program(program, grammar)
                          .verify_special_forms
         tree = Dote::SyntaxPass.build_tree(token_sequence, grammar)
+      if files[:output_file].nil?
         Dote::CodeGen.make_file(tree,
                                 grammar,
                                 File.dirname(files[:input_file]),
                                 File.basename(files[:input_file]))
+      else
+        if File.extname(files[:output_file]).empty?
+          files[:output_file] = files[:output_file].dup.concat(".dt")
+        end
+        Dote::CodeGen.make_file(tree,
+                                grammar,
+                                File.dirname(files[:output_file]),
+                                File.basename(files[:output_file]))
       end
     end
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -19,15 +19,31 @@ describe "cli" do
   describe "fmt" do
     before do
       get_code_gen_dir
-      @input_path = get_test_input_path('dotef_input')
+      @input_file_path = File.join(get_code_gen_dir, 'dotef_input.dt')
+      FileUtils.cp(get_test_input_path('dotef_input'), @input_file_path)
     end
     it "rewrites input file" do
-      new_input_path = File.join(get_code_gen_dir, 'dotef_input.dt')
-      FileUtils.cp(@input_path, new_input_path)
-      `#{@path} fmt #{new_input_path}`
+      `#{@path} fmt #{@input_file_path}`
       @output = load_test_inputs('dotef_output')
-      FileUtils.identical?(new_input_path,
+      FileUtils.identical?(@input_file_path,
                            get_test_input_path('dotef_output')).must_equal true
+    end
+    describe "writes_new_file" do
+      it "includes file extension" do
+        json_file = 'fmt_output.json'
+        `#{@path} fmt #{@input_file_path} #{json_file}`
+        FileUtils.identical?(json_file,
+                             get_test_input_path('dotef_output')).must_equal true
+        FileUtils.rm(json_file)
+      end
+      it "without file extension" do
+        file_input_path = 'fmt_output'
+        output_file = file_input_path.concat('.dt')
+        `#{@path} fmt #{@input_file_path} #{file_input_path}`
+        FileUtils.identical?(output_file,
+                             get_test_input_path('dotef_output')).must_equal true
+        FileUtils.rm(output_file)
+      end
     end
     after do
       FileUtils.rm_rf(get_code_gen_dir)


### PR DESCRIPTION
fmt command now takes a second input and writes the formatted program to this file instead of rewriting the first input.
